### PR TITLE
Fix event loss - Implemented circular buffer for event buffering

### DIFF
--- a/source/mouse.h
+++ b/source/mouse.h
@@ -13,6 +13,8 @@ struct MouseEvent {
 	CGEventType type;
 };
 
+const unsigned int BUFFER_SIZE = 10;
+
 class Mouse : public Nan::ObjectWrap {
 	public:
 		static void Initialize(Handle<Object> exports);
@@ -24,7 +26,6 @@ class Mouse : public Nan::ObjectWrap {
 		void HandleSend();
 
 	private:
-		MouseEvent* event;
 		Nan::Callback* event_callback;
 		uv_async_t* async;
 		uv_mutex_t async_lock;
@@ -33,7 +34,9 @@ class Mouse : public Nan::ObjectWrap {
 		uv_mutex_t async_cond_lock;
 		CFRunLoopRef loop_ref;
 		bool stopped;
-
+		MouseEvent* eventBuffer[BUFFER_SIZE];
+		unsigned int readIndex;
+		unsigned int writeIndex;
 		explicit Mouse(Nan::Callback*);
 		~Mouse();
 


### PR DESCRIPTION
This fixes the loss of concurrent mouse events. 
`-drag` and `-move` events can be concurrently emitted with all the `-down` or `-up` events.

Implemented a circular buffer of `MouseEvent` to store unprocessed events between the system event thread and the JS callback thread.

Tested in 10.13 High Sierra