### PR TITLE
fix: support V8 >= 7.1

### DIFF
--- a/source/addon.cc
+++ b/source/addon.cc
@@ -1,7 +1,7 @@
 #include "mouse.h"
 
-void Initialize(Handle<Object> exports) {
-	Mouse::Initialize(exports);
+NAN_MODULE_INIT(Initialize) {
+	Mouse::Initialize(target);
 }
 
 NODE_MODULE(addon, Initialize)

--- a/source/mouse.cc
+++ b/source/mouse.cc
@@ -76,7 +76,7 @@ Mouse::~Mouse() {
 	}
 }
 
-void Mouse::Initialize(Handle<Object> exports) {
+void Mouse::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(Mouse::New);

--- a/source/mouse.h
+++ b/source/mouse.h
@@ -17,7 +17,7 @@ const unsigned int BUFFER_SIZE = 10;
 
 class Mouse : public Nan::ObjectWrap {
 	public:
-		static void Initialize(Handle<Object> exports);
+		static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports);
 		static Nan::Persistent<Function> constructor;
 		void Run();
 		void Stop();


### PR DESCRIPTION
`v8::Handle` has been deprecated for a while (since IOJS 3)

This PR replaces all references to `v8::Handle` with the `Nan` typedefs so that it remains backwards compatible but also works on V8 versions that don't have `Handle` anymore.

This is required to support Electron 5 and node 12 in the future.