### PR TITLE
Fix compatibility with node 12 and 13, electron 6 and 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "osx-mouse",
+  "version": "1.3.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/kapetan/osx-mouse",
   "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.10.0"
+    "bindings": "^1.5.0",
+    "nan": "^2.14.0"
   },
   "os": [
     "darwin"

--- a/source/addon.cc
+++ b/source/addon.cc
@@ -1,7 +1,7 @@
 #include "mouse.h"
 
-void Initialize(Handle<Object> exports) {
-	Mouse::Initialize(exports);
+NAN_MODULE_INIT(Initialize) {
+	Mouse::Initialize(target);
 }
 
 NODE_MODULE(addon, Initialize)

--- a/source/mouse.cc
+++ b/source/mouse.cc
@@ -76,7 +76,7 @@ Mouse::~Mouse() {
 	}
 }
 
-void Mouse::Initialize(Handle<Object> exports) {
+void Mouse::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(Mouse::New);
@@ -87,8 +87,8 @@ void Mouse::Initialize(Handle<Object> exports) {
 	Nan::SetPrototypeMethod(tpl, "ref", Mouse::AddRef);
 	Nan::SetPrototypeMethod(tpl, "unref", Mouse::RemoveRef);
 
-	Mouse::constructor.Reset(tpl->GetFunction());
-	exports->Set(Nan::New<String>("Mouse").ToLocalChecked(), tpl->GetFunction());
+	Mouse::constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+	exports->Set(Nan::New<String>("Mouse").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 void Mouse::Run() {

--- a/source/mouse.cc
+++ b/source/mouse.cc
@@ -88,7 +88,7 @@ void Mouse::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::SetPrototypeMethod(tpl, "unref", Mouse::RemoveRef);
 
 	Mouse::constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
-	exports->Set(Nan::New<String>("Mouse").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+	Nan::Set(exports, Nan::New<String>("Mouse").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 void Mouse::Run() {

--- a/source/mouse.h
+++ b/source/mouse.h
@@ -17,7 +17,7 @@ const unsigned int BUFFER_SIZE = 10;
 
 class Mouse : public Nan::ObjectWrap {
 	public:
-		static void Initialize(Handle<Object> exports);
+		static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports);
 		static Nan::Persistent<Function> constructor;
 		void Run();
 		void Stop();


### PR DESCRIPTION
I was trying to update my node version and electron version, and was limited by this package. I built on top of  https://github.com/kapetan/osx-mouse/pull/9 and fixed a couple other things.