### PR TITLE
Im/update binding gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "openssl_fips": "",
+    },
 	"targets": [
 		{
 			"target_name": "addon",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kapetan/osx-mouse"
+    "url": "https://github.com/loomhq/osx-mouse"
   },
   "keywords": [
     "track",
@@ -22,12 +22,12 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kapetan/osx-mouse/issues"
+    "url": "https://github.com/loomhq/osx-mouse/issues"
   },
-  "homepage": "https://github.com/kapetan/osx-mouse",
+  "homepage": "https://github.com/loomhq/osx-mouse",
   "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.10.0"
+    "bindings": "^1.5.0",
+    "nan": "^2.14.0"
   },
   "os": [
     "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osx-mouse",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Mouse tracking for OS X",
   "main": "index.js",
   "scripts": {

--- a/source/addon.cc
+++ b/source/addon.cc
@@ -1,7 +1,7 @@
 #include "mouse.h"
 
-void Initialize(Handle<Object> exports) {
-	Mouse::Initialize(exports);
+NAN_MODULE_INIT(Initialize) {
+	Mouse::Initialize(target);
 }
 
 NODE_MODULE(addon, Initialize)

--- a/source/mouse.cc
+++ b/source/mouse.cc
@@ -76,7 +76,7 @@ Mouse::~Mouse() {
 	}
 }
 
-void Mouse::Initialize(Handle<Object> exports) {
+void Mouse::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports) {
 	Nan::HandleScope scope;
 
 	Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(Mouse::New);
@@ -87,8 +87,8 @@ void Mouse::Initialize(Handle<Object> exports) {
 	Nan::SetPrototypeMethod(tpl, "ref", Mouse::AddRef);
 	Nan::SetPrototypeMethod(tpl, "unref", Mouse::RemoveRef);
 
-	Mouse::constructor.Reset(tpl->GetFunction());
-	exports->Set(Nan::New<String>("Mouse").ToLocalChecked(), tpl->GetFunction());
+	Mouse::constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+	Nan::Set(exports, Nan::New<String>("Mouse").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 void Mouse::Run() {

--- a/source/mouse.h
+++ b/source/mouse.h
@@ -17,7 +17,7 @@ const unsigned int BUFFER_SIZE = 10;
 
 class Mouse : public Nan::ObjectWrap {
 	public:
-		static void Initialize(Handle<Object> exports);
+		static void Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE exports);
 		static Nan::Persistent<Function> constructor;
 		void Run();
 		void Stop();


### PR DESCRIPTION
Updates `binding.gyp`. We're moving to Node 18 in the desktop repo and this dependency needs to avoid looking for an openssl_fips certificate when being built with `node-gyp` 